### PR TITLE
hightlight the slack channel with a badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# QuoteCenter Technology Radar <a href="https://slack.com/app_redirect?channel=technology-radar"><img src="https://img.shields.io/badge/slack-%23technology--radar-ff69b4.svg"></a>
+# QuoteCenter Technology Radar <a href="https://hdqc.slack.com/app_redirect?channel=technology-radar"><img src="https://img.shields.io/badge/slack-%23technology--radar-ff69b4.svg"></a>
 
 Technology Radar is a listing of technologies and methodologies adopted (or on their way to adoption) at QC.  Where they are on that path is represented by a set of concentric rings approaching and peaking with adoption, followed by a path that they take on their way out of adoption.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# QuoteCenter Technology Radar
+# QuoteCenter Technology Radar <a href="https://slack.com/app_redirect?channel=technology-radar"><img src="https://img.shields.io/badge/slack-%23technology--radar-ff69b4.svg"></a>
 
 Technology Radar is a listing of technologies and methodologies adopted (or on their way to adoption) at QC.  Where they are on that path is represented by a set of concentric rings approaching and peaking with adoption, followed by a path that they take on their way out of adoption.
 


### PR DESCRIPTION
This repo has a slack channel, but the channel name got a little buried in the readme. This PR adds a  slack link in the form of a badge next to the title. Clicking the link will open the channel as long as the hdqc space is active. 

This is the link to my branch's readme:
https://github.com/mackenzie-orange/technology-radar/tree/slack-badge-time

see this page for details:
https://api.slack.com/docs/deep-linking